### PR TITLE
Fixing $this call on closure for still be PHP 5.3.x compatible.

### DIFF
--- a/src/CurlRemoteFilesystem.php
+++ b/src/CurlRemoteFilesystem.php
@@ -88,12 +88,13 @@ class CurlRemoteFilesystem extends Util\RemoteFilesystem
      */
     public function getContents($origin, $fileUrl, $progress=true, $options=array())
     {
-        return $this->fetch($origin, $fileUrl, $progress, $options, function($ch, $request){
+        $obj = $this;
+        return $this->fetch($origin, $fileUrl, $progress, $options, function($ch, $request, &$obj){
             // This order is important.
             curl_setopt($ch, CURLOPT_FILE, STDOUT);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
-            return $this->exec($ch, $request);
+            return $obj->exec($ch, $request);
         });
     }
 

--- a/src/CurlRemoteFilesystem.php
+++ b/src/CurlRemoteFilesystem.php
@@ -89,7 +89,7 @@ class CurlRemoteFilesystem extends Util\RemoteFilesystem
     public function getContents($origin, $fileUrl, $progress=true, $options=array())
     {
         $obj = $this;
-        return $this->fetch($origin, $fileUrl, $progress, $options, function($ch, $request, &$obj){
+        return $this->fetch($origin, $fileUrl, $progress, $options, function($ch, $request) use (&$obj){
             // This order is important.
             curl_setopt($ch, CURLOPT_FILE, STDOUT);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Since in composer.json the minimum version required of PHP is 5.3.x, people are using it with that version. This pull request fix the issue #16. Please note that the pull request #19 also fix other issue related with CurlRemoteFilesystem.php file.