### PR TITLE
Fixed Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ HTTP/1.1 pipelining option. It needs PHP `>=5.5`.
 ### insecure (bool)
 * default: false
 
-If insecure is true, this plugin doesn't verify all https certs. (`CURLOPT_VERIFYPEER` is off)
+If insecure is true, this plugin doesn't verify all https certs. (`CURLOPT_SSL_VERIFYPEER` is off)
 You SHOULD NOT change this option.
 
 ### capath (string)

--- a/src/CurlRemoteFilesystem.php
+++ b/src/CurlRemoteFilesystem.php
@@ -153,7 +153,7 @@ class CurlRemoteFilesystem extends Util\RemoteFilesystem
             $ch = Factory::getConnection($origin, isset($opts[CURLOPT_USERPWD]));
 
             if ($this->pluginConfig['insecure']) {
-                $opts[CURLOPT_VERIFYPEER] = false;
+                $opts[CURLOPT_SSL_VERIFYPEER] = false;
             }
             if (! empty($pluginConfig['capath'])) {
                 $opts[CURLOPT_CAPATH] = $pluginConfig['capath'];

--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -101,7 +101,7 @@ class ParallelDownloader
 
                 $opts = $request->getCurlOpts();
                 if ($pluginConfig['insecure']) {
-                    $opts[CURLOPT_VERIFYPEER] = false;
+                    $opts[CURLOPT_SSL_VERIFYPEER] = false;
                 }
                 if (! empty($pluginConfig['capath'])) {
                     $opts[CURLOPT_CAPATH] = $pluginConfig['capath'];


### PR DESCRIPTION
Fixed typo which caused the following error after PR #23  

```
Use of undefined constant CURLOPT_VERIFYPEER - assumed 'CURLOPT_VERIFYPEER'
```
Should be `CURLOPT_SSL_VERIFYPEER` instead