### PR TITLE
Avoid error when no dist urls are defined at all

### DIFF
--- a/src/ParallelDownloader.php
+++ b/src/ParallelDownloader.php
@@ -90,7 +90,11 @@ class ParallelDownloader
 
             // make url
             $url = $package->getDistUrls();
-            $url = $url[0];
+            if (count($url) > 0) {
+                $url = $url[0];
+            } else {
+                $url = $package->getDistUrl();
+            }
             $host = parse_url($url, PHP_URL_HOST) ?: '';
             $request = new Aspects\HttpGetRequest($host, $url, $this->io);
             $request->verbose = $pluginConfig['verbose'];


### PR DESCRIPTION
We are using our own Satis with Gitlab and it generates dist url for zipped project.
With the last version (and the PR #37), I got an error when updating deps:

```
jeremy@ox-dev:~/project$ composer install -vvvv
You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug
Loading composer repositories with package information
Installing dependencies (including require-dev)
    Prefetch start: success: 0, failure: 0, total: 38


  [ErrorException]
  Undefined offset: 0


install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-plugins] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--ignore-platform-reqs] [--] [<packages>]...
```

Everything worked fine with version 0.1.7.
So I added an extra test to avoid error (and exception) when a package doesn't have a dist urls.