### PR TITLE
Increase retryCount for curl multi to 100

### DIFF
--- a/src/CurlMulti.php
+++ b/src/CurlMulti.php
@@ -108,7 +108,7 @@ class CurlMulti
             } while ($stat === CURLM_CALL_MULTI_PERFORM);
             if (-1 === curl_multi_select($this->mh)) {
                 // @codeCoverageIgnoreStart
-                if ($retryCnt++ > 10) {
+                if ($retryCnt++ > 100) {
                     throw new \RuntimeException('curl_multi_select failure');
                 }
                 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
Since on some systems it takes more then 10 trys to get the sockets.

Should fix #64 