### PR TITLE
Use Authorization header for HTTP Basic

### DIFF
--- a/src/Aspects/HttpGetRequest.php
+++ b/src/Aspects/HttpGetRequest.php
@@ -119,11 +119,11 @@ class HttpGetRequest
         $headers = $this->headers;
         if ($this->username && $this->password) {
             foreach ($headers as $i => $header) {
-                if (0 === strpos($header, 'Authentication:')) {
+                if (0 === strpos($header, 'Authorization:')) {
                     unset($headers[$i]);
                 }
             }
-            $headers[] = 'Authentication: Basic ' . base64_encode("$this->username:$this->password");
+            $headers[] = 'Authorization: Basic ' . base64_encode("$this->username:$this->password");
         }
 
         $curlOpts = $this->curlOpts + array(

--- a/tests/unit/Aspects/HttpGetRequestTest.php
+++ b/tests/unit/Aspects/HttpGetRequestTest.php
@@ -105,7 +105,7 @@ class HttpGetRequestTest extends \PHPUnit_Framework_TestCase
 
         $req->username = 'ninja';
         $req->password = 'aieee';
-        $expects[CURLOPT_HTTPHEADER][] = 'Authentication: Basic ' . base64_encode('ninja:aieee');
+        $expects[CURLOPT_HTTPHEADER][] = 'Authorization: Basic ' . base64_encode('ninja:aieee');
         $curlOpts = $req->getCurlOpts();
         unset($curlOpts[CURLOPT_USERAGENT]);
         self::assertEquals($expects, $curlOpts);


### PR DESCRIPTION
This plugin started to use the header `Authentication` instead of `CURLOPT_USERPWD` a few days ago which broke downloading from HTTP Basic protected sources. This PR changes the header used to `Authorization` which is what HTTP Basic actually uses :)