### PR TITLE
depend on stable released Composer plugin API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "require": {
         "php": ">=5.3.2",
         "ext-curl": "*",
-        "composer-plugin-api": "~1.0.0-alpha10"
+        "composer-plugin-api": "~1.0.0-alpha10 || ^1.0"
     },
     "require-dev": {
-        "composer/composer": "1.0.0-alpha10",
+        "composer/composer": "~1.0.0-alpha10 || ^1.0",
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.5"
     },


### PR DESCRIPTION
This will also make it possible to use the plugin with a `1.1.x`
development version of Composer.