### PR TITLE
Fix gitlab domains error

### DIFF
--- a/src/BaseRequest.php
+++ b/src/BaseRequest.php
@@ -115,7 +115,7 @@ class BaseRequest
      * @param $githubDomains
      * @param $gitlabDomains
      */
-    protected function setupAuthentication(IO\IOInterface $io, $useRedirector, array $githubDomains, array $gitlabDomains)
+    protected function setupAuthentication(IO\IOInterface $io, $useRedirector, array $githubDomains = array(), array $gitlabDomains = array())
     {
         if (preg_match('/\.github\.com$/', $this->host)) {
             $authKey = 'github.com';


### PR DESCRIPTION
Composer install fails when gitlab-domains option is not present in composer config

```
 [ErrorException]                                                                                                                                                                           
  Argument 4 passed to Hirak\Prestissimo\BaseRequest::setupAuthentication() must be of the type array, null given, called in /home/nikolaev/.composer/vendor/hirak/prestissimo/src/CopyRequ  
  est.php on line 41 and defined  
```

