### PR TITLE
Disable on missing curl extension, fixes #145

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -56,6 +56,11 @@ class Plugin implements
         if (__CLASS__ !== 'Hirak\Prestissimo\Plugin') {
             return $this->disable();
         }
+        // guard for missing curl extension problem
+        if (!extension_loaded('curl')) {
+            $io->writeError('<error>Error: "curl" PHP extension not loaded; Prestissmo Composer plugin disabled.</error>');
+            return $this->disable();
+        }
         // @codeCoverageIgnoreEnd
 
         // load all classes


### PR DESCRIPTION
Previously when the curl extension was not loaded, the Prestissimo
plugin prevented composer usage due to ErrorExceptions.

Fix is to check if the "curl" module is loaded and if not, to disable
the plugin.

Composer itself can work w/o Curl so this change is a stability
fallback.