### PR TITLE
use Ubuntu trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: false
+dist: trusty
 
 cache: vendor
 


### PR DESCRIPTION
I've found CI fails for HHVM.
https://travis-ci.org/hirak/prestissimo/jobs/259213365

```
HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
```

So this PR tries to use `trusty` image.
