### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "composer/composer": "1.0.0",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.35",
         "squizlabs/php_codesniffer": "^2.5"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "34e51752c8c7c595bb39ded22c3d840b",
+    "content-hash": "1f8ec64a8ef26ed91ecb78b8c1d3f8f3",
     "packages": [],
     "packages-dev": [
         {

--- a/tests/unit/BaseRequestTest.php
+++ b/tests/unit/BaseRequestTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Hirak\Prestissimo;
 
-class BaseRequestTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BaseRequestTest extends TestCase
 {
     public function testSetURL()
     {

--- a/tests/unit/ConfigFacadeTest.php
+++ b/tests/unit/ConfigFacadeTest.php
@@ -2,8 +2,9 @@
 namespace Hirak\Prestissimo;
 
 use Composer\Config;
+use PHPUnit\Framework\TestCase;
 
-class ConfigFacadeTest extends \PHPUnit_Framework_TestCase
+class ConfigFacadeTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/unit/CopyRequestTest.php
+++ b/tests/unit/CopyRequestTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Hirak\Prestissimo;
 
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument as arg;
 
-class CopyRequestTest extends \PHPUnit_Framework_TestCase
+class CopyRequestTest extends TestCase
 {
     private $iop;
     private $configp;

--- a/tests/unit/CurlMultiTest.php
+++ b/tests/unit/CurlMultiTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Hirak\Prestissimo;
 
-class CurlMultiTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CurlMultiTest extends TestCase
 {
     private $iop;
     private $configp;

--- a/tests/unit/CurlRemoteFilesystemTest.php
+++ b/tests/unit/CurlRemoteFilesystemTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Hirak\Prestissimo;
 
-class CurlRemoteFilesystemTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CurlRemoteFilesystemTest extends TestCase
 {
     // dummy objects
     private $iop;

--- a/tests/unit/ParallelizedComposerRepositoryTest.php
+++ b/tests/unit/ParallelizedComposerRepositoryTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Hirak\Prestissimo;
 
-class ParallelizedComposerRepositoryTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ParallelizedComposerRepositoryTest extends TestCase
 {
     public function testPrefetch()
     {

--- a/tests/unit/PluginTest.php
+++ b/tests/unit/PluginTest.php
@@ -4,8 +4,9 @@ namespace Hirak\Prestissimo;
 use Composer\Composer;
 use Composer\DependencyResolver\Operation;
 use Composer\Package;
+use PHPUnit\Framework\TestCase;
 
-class PluginTest extends \PHPUnit_Framework_TestCase
+class PluginTest extends TestCase
 {
     // dummy objects
     private $iop;

--- a/tests/unit/PrefetcherTest.php
+++ b/tests/unit/PrefetcherTest.php
@@ -2,9 +2,10 @@
 namespace Hirak\Prestissimo;
 
 use Composer\IO\IOInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument as arg;
 
-class PrefetcherTest extends \PHPUnit_Framework_TestCase
+class PrefetcherTest extends TestCase
 {
     private $iop;
     private $configp;

--- a/tests/unit/ShareTest.php
+++ b/tests/unit/ShareTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Hirak\Prestissimo;
 
-class ShareTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ShareTest extends TestCase
 {
     public function testSetup()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and, that support this namespace.