### PR TITLE
add php 5.3 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,10 @@ script:
 after_success:
   - php bin/ocular.phar code-coverage:upload --format=php-clover artifacts/clover.xml
   - php bin/coveralls.phar -v
+
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      dist: precise
+      php: 5.3


### PR DESCRIPTION
prestissimo looks to support PHP5.3 , according to the `composer.json`.
So, I think it's better to run it on travis.