### PR TITLE
Default request empty array value.

### DIFF
--- a/src/CurlMulti.php
+++ b/src/CurlMulti.php
@@ -20,10 +20,10 @@ class CurlMulti
     private $using = array();
 
     /** @var CopyRequest[] */
-    private $requests;
+    private $requests = array();
 
     /** @var CopyRequest[] */
-    private $runningRequests;
+    private $runningRequests = array();
 
     /** @var bool */
     private $permanent = true;


### PR DESCRIPTION
To avoid 

count(): Parameter must be an array or an object that implements Countable

in remain method. Count function can't count NULLvalue.