### PR TITLE
Add support for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
 
 before_install:
   - composer config -g repositories.packagist path $(pwd)


### PR DESCRIPTION
It was just released on 6 Dec 2018.

https://secure.php.net/supported-versions.php