### PR TITLE
 Drop support for EOL PHP 5.3-5.6 and 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 cache: vendor
 
 php:
-  - '5.6'
   - '7.1'
   - '7.2'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ sudo: false
 cache: vendor
 
 php:
-  - '5.4'
-  - '5.5'
   - '5.6'
-  - '7.0'
   - '7.1'
   - '7.2'
 
@@ -25,10 +22,3 @@ script:
 after_success:
   - php bin/ocular.phar code-coverage:upload --format=php-clover artifacts/clover.xml
   - php bin/coveralls.phar -v
-
-matrix:
-  include:
-    - os: linux
-      sudo: required
-      dist: precise
-      php: 5.3


### PR DESCRIPTION
* PHP 5.3-5.5 and 7.0 are EOL
* PHP 5.6 is EOL at the end of this month

![image](https://user-images.githubusercontent.com/1324225/49799188-fe43d400-fd4c-11e8-869b-d70153153afa.png)

https://secure.php.net/supported-versions.php