### PR TITLE
Fix prestissimo to ignore curl error message unless error code is set

### DIFF
--- a/src/CurlMulti.php
+++ b/src/CurlMulti.php
@@ -129,6 +129,8 @@ class CurlMulti
             if ($raised = curl_multi_info_read($this->mh, $remains)) {
                 $ch = $raised['handle'];
                 $errno = curl_errno($ch);
+                if($errno == CURLE_OK && $raised['result'] != CURLE_OK)
+                    $errno = $raised['result'];
                 $error = curl_error($ch);
                 $info = curl_getinfo($ch);
                 curl_setopt($ch, CURLOPT_FILE, $this->blackhole); //release file pointer

--- a/src/CurlMulti.php
+++ b/src/CurlMulti.php
@@ -134,7 +134,7 @@ class CurlMulti
                 curl_setopt($ch, CURLOPT_FILE, $this->blackhole); //release file pointer
                 $index = (int)$ch;
                 $request = $this->runningRequests[$index];
-                if (CURLE_OK === $errno && !$error && ('http' !== substr($info['url'], 0, 4) || 200 === $info['http_code'])) {
+                if (CURLE_OK === $errno && ('http' !== substr($info['url'], 0, 4) || 200 === $info['http_code'])) {
                     ++$successCnt;
                     $request->makeSuccess();
                     $urls[] = $request->getMaskedURL();


### PR DESCRIPTION
There's currently a bug in curl 7.64 where it puts host not resolved errors in the error buffer even though the host has been found and the download was successful.

This bug is causing prestissimo to claim that it failed to download most of its packages, thus causing composer to download them again serially.

While the bug is in curl, according to [the libcurl man page](https://curl.haxx.se/libcurl/c/CURLOPT_ERRORBUFFER.html), the error buffer should be ignored unless an error code is returned, so prestissimo shouldn't be checking the error buffer when determining whether a download succeeded.  This patch contains the fix.