### PR TITLE
drop SensioLabs Insight badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ prestissimo (composer plugin)
 [![Latest Stable Version](https://poser.pugx.org/hirak/prestissimo/v/stable)](https://packagist.org/packages/hirak/prestissimo)
 [![Total Downloads](https://poser.pugx.org/hirak/prestissimo/downloads)](https://packagist.org/packages/hirak/prestissimo)
 [![License](https://poser.pugx.org/hirak/prestissimo/license)](https://packagist.org/packages/hirak/prestissimo)  
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/56ca0f9e-63a2-4e89-b5f8-e0cc39d0c38f/big.png)](https://insight.sensiolabs.com/projects/56ca0f9e-63a2-4e89-b5f8-e0cc39d0c38f)
 
 This is a [composer](https://getcomposer.org) plugin that downloads packages in parallel to speed up the installation process. 
 


### PR DESCRIPTION
- insight.sensiolabs.com reformed as insight.symfony.com
- `Symfony Insight` do not provide OSS free plan. https://insight.symfony.com/pricing
- So I decided to drop SensioLabs Insight.

TODO:
- investigate another static analysis tool; such as PHPStan.