### PR TITLE
Show failure message

### DIFF
--- a/src/CurlMulti.php
+++ b/src/CurlMulti.php
@@ -137,10 +137,10 @@ class CurlMulti
                 curl_setopt($ch, CURLOPT_FILE, $this->blackhole); //release file pointer
                 $index = (int)$ch;
                 $request = $this->runningRequests[$index];
+                $urls[] = $request->getMaskedURL();
                 if (CURLE_OK === $errno && ('http' !== substr($info['url'], 0, 4) || 200 === $info['http_code'])) {
                     ++$successCnt;
                     $request->makeSuccess();
-                    $urls[] = $request->getMaskedURL();
                 } else {
                     ++$failureCnt;
                     $errors[$request->getMaskedURL()] = "$errno: $error";

--- a/tests/unit/PrefetcherTest.php
+++ b/tests/unit/PrefetcherTest.php
@@ -26,6 +26,8 @@ class PrefetcherTest extends \PHPUnit\Framework\TestCase
             CURLOPT_URL => 'file://uso800.txt',
             CURLOPT_FILE => tmpfile(),
         ));
+     
+        $this->iop->writeError(arg::containingString("<warning>37: Couldn't open file /uso800.txt</warning>"), true, IOInterface::NORMAL)->shouldBeCalledTimes(1);
         $this->iop->writeError("    Finished: <comment>success: 0, skipped: 0, failure: 1, total: 1</comment>", true, IOInterface::NORMAL)->shouldBeCalledTimes(1);
 
         $fetcher = new Prefetcher;


### PR DESCRIPTION
Before this change - in case of a failure - output was looking like this:
```bash
Updating dependencies (including require-dev)
    Finished: success: 0, skipped: 0, failure: 2, total: 2
Package operations: ...
```
After this change it would look like this:
```bash
Updating dependencies (including require-dev)
    60: SSL certificate problem: unable to get local issuer certificate:        https://codeload.github.com/Ocramius/PackageVersions/legacy.zip/1d32342b8c1eb27353c8887c366147b4c2da673c
    60: SSL certificate problem: unable to get local issuer certificate:        https://codeload.github.com/symfony/event-dispatcher/legacy.zip/b3c3068a72623287550fe20b84a2b01dcba2686f
    Finished: success: 0, skipped: 0, failure: 2, total: 2
Package operations: ...
```