### PR TITLE
Use authorization: token header for Github authentication

### DIFF
--- a/src/BaseRequest.php
+++ b/src/BaseRequest.php
@@ -142,7 +142,7 @@ class BaseRequest
 
         // is github
         if (in_array($authKey, $githubDomains) && 'x-oauth-basic' === $auth['password']) {
-            $this->addParam('access_token', $auth['username']);
+            $this->addHeader('authorization', 'token ' . $auth['username']);
             $this->user = $this->pass = null;
             return;
         }

--- a/tests/unit/CopyRequestTest.php
+++ b/tests/unit/CopyRequestTest.php
@@ -89,11 +89,13 @@ class CopyRequestTest extends \PHPUnit\Framework\TestCase
 
         // user:pass -> query
         $req = new CopyRequest($example, $tmpfile, false, $this->iop->reveal(), $this->configp->reveal());
-        $this->assertEquals("$example&access_token=at", $req->getURL());
+        $opts = $req->getCurlOptions();
+        $this->assertContains('Authorization: token at', $opts[CURLOPT_HTTPHEADER]);
 
         // api.github.com -> codeload.github.com
         $req = new CopyRequest($example, $tmpfile, true, $this->iop->reveal(), $this->configp->reveal());
-        $this->assertEquals('https://codeload.github.com/vendor/name/legacy.zip/aaaa?a=b&access_token=at', $req->getURL());
+        $opts = $req->getCurlOptions();
+        $this->assertContains('Authorization: token at', $opts[CURLOPT_HTTPHEADER]);
     }
 
     public function testGitLab()

--- a/tests/unit/CopyRequestTest.php
+++ b/tests/unit/CopyRequestTest.php
@@ -89,11 +89,13 @@ class CopyRequestTest extends \PHPUnit\Framework\TestCase
 
         // user:pass -> query
         $req = new CopyRequest($example, $tmpfile, false, $this->iop->reveal(), $this->configp->reveal());
+        $this->assertEquals($example, $req->getURL());
         $opts = $req->getCurlOptions();
         $this->assertContains('Authorization: token at', $opts[CURLOPT_HTTPHEADER]);
 
         // api.github.com -> codeload.github.com
         $req = new CopyRequest($example, $tmpfile, true, $this->iop->reveal(), $this->configp->reveal());
+        $this->assertEquals('https://codeload.github.com/vendor/name/legacy.zip/aaaa?a=b', $req->getURL());
         $opts = $req->getCurlOptions();
         $this->assertContains('Authorization: token at', $opts[CURLOPT_HTTPHEADER]);
     }


### PR DESCRIPTION
Fixes GitHub deprecated query param authentication #210