### PR TITLE
fix `--no-cache` support

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -74,6 +74,7 @@ class Plugin implements
 
         $cacheDir = rtrim($this->config->get('cache-files-dir'), '\/');
 
+        // disable when cache is not usable
         if (preg_match('{(^|[\\\\/])(\$null|nul|NUL|/dev/null)([\\\\/]|$)}', $cacheDir)) {
             return $this->disable();
         }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -72,6 +72,12 @@ class Plugin implements
         $this->config = $composer->getConfig();
         $this->package = $composer->getPackage();
 
+        $cacheDir = rtrim($this->config->get('cache-files-dir'), '\/');
+
+        if (preg_match('{(^|[\\\\/])(\$null|nul|NUL|/dev/null)([\\\\/]|$)}', $cacheDir)) {
+            return $this->disable();
+        }
+
         if (array_key_exists('argv', $GLOBALS)) {
             if (in_array('help', $GLOBALS['argv'])) {
                 return $this->disable();

--- a/tests/unit/PluginTest.php
+++ b/tests/unit/PluginTest.php
@@ -103,6 +103,30 @@ class PluginTest extends \PHPUnit\Framework\TestCase
         $plugin->onPostDependenciesSolving($evp->reveal());
     }
 
+    /**
+     * @dataProvider nullCacheDataProvider
+     */
+    public function testDisabledWhenCacheIsOff($cacheDir)
+    {
+        $plugin = new Plugin;
+        $this->configp->get('cache-files-dir')
+            ->willReturn($cacheDir);
+
+        $plugin->activate($this->composerp->reveal(), $this->iop->reveal());
+
+        $this->assertTrue($plugin->isDisabled());
+    }
+
+    public function nullCacheDataProvider()
+    {
+        return array(
+            array('$null'),
+            array('nul'),
+            array('NUL'),
+            array('/dev/null'),
+        );
+    }
+
     private function createDummyOperations()
     {
         return array(


### PR DESCRIPTION
This change disables prestissimo when `--no-cache` flag is passed.
Regex is taken from https://github.com/composer/composer/blob/f154d5c09d69a6338d6a955bf51cc264d0448b3d/src/Composer/Cache.php#L62-L65

fixes #199
