### PR TITLE
Support Composer API v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.3.2 || ^7.0",
         "ext-curl": "*",
-        "composer-plugin-api": "^1.0.0"
+        "composer-plugin-api": "~1.0.0"
     },
     "require-dev": {
         "composer/composer": "1.0.0",


### PR DESCRIPTION
Enabled composer ~1.0.0 in order to accept new composer api version.

also not work with   composer install --ignore-platform-reqs

resolve issue #218 

```
akeneo | Using version ^0.3.10 for hirak/prestissimo
akeneo | ./composer.json has been created
akeneo | Loading composer repositories with package information
akeneo | Updating dependencies
akeneo | Your requirements could not be resolved to an installable set of packages.
akeneo |
akeneo | Problem 1
akeneo | - Root composer.json requires hirak/prestissimo ^0.3.10 -> satisfiable by hirak/prestissimo[0.3.10].
akeneo | - hirak/prestissimo 0.3.10 requires composer-plugin-api ^1.0.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
akeneo | You are using a snapshot build of Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report an issue to them to ask them to support Composer 2. To work around this you can run Composer with --ignore-platform-reqs, but this will also ignore your PHP version and may result in bigger problems down the line.
akeneo | Installation failed, deleting ./composer.json.
```