### PR TITLE
Fix Too many files open errors with large composer setups

### DIFF
--- a/src/CopyRequest.php
+++ b/src/CopyRequest.php
@@ -69,6 +69,16 @@ class CopyRequest extends BaseRequest
      */
     public function getCurlOptions()
     {
+        if ($this->fp) {
+            fclose($this->fp);
+        }
+        $this->fp = fopen($this->destination, 'wb');
+        if (!$this->fp) {
+            throw new FetchException(
+                'The file could not be written to ' . $this->destination
+            );
+        }
+
         $curlOpts = parent::getCurlOptions();
         $curlOpts[CURLOPT_FILE] = $this->fp;
         return $curlOpts;
@@ -87,13 +97,6 @@ class CopyRequest extends BaseRequest
         }
 
         $this->createDir($destination);
-
-        $this->fp = fopen($destination, 'wb');
-        if (!$this->fp) {
-            throw new FetchException(
-                'The file could not be written to ' . $destination
-            );
-        }
     }
 
     private function createDir($fileName)

--- a/src/CopyRequest.php
+++ b/src/CopyRequest.php
@@ -17,7 +17,7 @@ class CopyRequest extends BaseRequest
     /** @var resource<stream<plainfile>> */
     private $fp;
 
-    private $success = false;
+    private $success = true;
 
     protected static $defaultCurlOptions = array(
         CURLOPT_HTTPGET => true,
@@ -72,6 +72,7 @@ class CopyRequest extends BaseRequest
         if ($this->fp) {
             fclose($this->fp);
         }
+        $this->success = false;
         $this->fp = fopen($this->destination, 'wb');
         if (!$this->fp) {
             throw new FetchException(

--- a/src/CurlMulti.php
+++ b/src/CurlMulti.php
@@ -88,7 +88,10 @@ class CurlMulti
     public function setupEventLoop()
     {
         while (count($this->unused) > 0 && count($this->requests) > 0) {
-            $request = array_pop($this->requests);
+            // Process request using a clone to ensure any memory we cause it to allocate is freed after we unset
+            // Otherwise, memory is still held for all requests due to it existing on the callstack
+            // Callers should not need to know this though
+            $request = clone array_pop($this->requests);
             $ch = array_pop($this->unused);
             $index = (int)$ch;
 

--- a/tests/unit/CopyRequestTest.php
+++ b/tests/unit/CopyRequestTest.php
@@ -60,10 +60,11 @@ class CopyRequestTest extends \PHPUnit\Framework\TestCase
         $tmpfile = tempnam(sys_get_temp_dir(), 'composer_unit_test_');
 
         $req = new CopyRequest('http://example.com/', $tmpfile, false, $this->iop->reveal(), $this->configp->reveal());
+        $req->getCurlOptions();
+        $req->makeSuccess();
         $this->assertFileExists($tmpfile);
 
-        // if $req->success === true ...
-        $req->makeSuccess();
+        // if $req->success === true (default, or on success) ...
         unset($req);
 
         // then tmpfile remain
@@ -71,8 +72,8 @@ class CopyRequestTest extends \PHPUnit\Framework\TestCase
         unlink($tmpfile);
 
         $req = new CopyRequest('http://example.com/', $tmpfile, false, $this->iop->reveal(), $this->configp->reveal());
-        // if $req->success === false (default) ...
-        // $req->makeSuccess();
+        // if $req->success === false (flagged when download starts) ...
+        $req->getCurlOptions();
         unset($req);
 
         // then cleaned tmpfile automatically

--- a/tests/unit/PrefetcherTest.php
+++ b/tests/unit/PrefetcherTest.php
@@ -26,7 +26,7 @@ class PrefetcherTest extends \PHPUnit\Framework\TestCase
             CURLOPT_URL => 'file://uso800.txt',
             CURLOPT_FILE => tmpfile(),
         ));
-     
+
         $this->iop->writeError(arg::containingString("<warning>37: Couldn't open file /uso800.txt</warning>"), true, IOInterface::NORMAL)->shouldBeCalledTimes(1);
         $this->iop->writeError("    Finished: <comment>success: 0, skipped: 0, failure: 1, total: 1</comment>", true, IOInterface::NORMAL)->shouldBeCalledTimes(1);
 


### PR DESCRIPTION
Fixes #226 

Issue is that CopyRequest opens a file descriptor during initialisation for all requests. Instead of opening it for a limited number of parallel requests. This resolves that by moving file descriptor open to getCurlOptions so it only happens for a small number of requests.

To ensure __destruct is called for the request it also clones the requests it processes before using them, so that the unset in CurlMulti correctly frees the memory. Otherwise, it's extremely hard and lots more modification to get them to free because the requests array exists on the call stack as a parameter. Cloning means the requests array is never modified and never allocated memory so removes a lot of requirements from the caller on freeing memory.

This allowed me to install a Magento 2 composer with 400+ packages successfully.