### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a [composer](https://getcomposer.org) plugin that downloads packages in 
 
 ## Requirements
 
-- composer `>=1.0.0` (includes dev-master)
+- composer `>=1.0.0 <2.0`
 - PHP `>=5.3`, (suggest `>=5.5`, because `curl_share_init`)
 - ext-curl
 


### PR DESCRIPTION
This plugin is not compatible with composer 2.0 and becomes obsolete since composer 2.0 does parallel downloads natively