### PR TITLE
RFC: composer 2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "require": {
         "php": "^5.3.2 || ^7.0",
         "ext-curl": "*",
-        "composer-plugin-api": "^1.0.0"
+        "composer-plugin-api": "^1.0.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "1.0.0",
+        "composer/composer": "1.0.0 || ^2.0@dev",
         "phpunit/phpunit": "4.8.* || 5.7.* || ^6.3",
         "squizlabs/php_codesniffer": "^2.5"
     },


### PR DESCRIPTION
a quick hack to allow the plugin to exist in environments where composer1 and composer2 are used. if composer2 is detected is simply deactivate itself. 
i am quite sure there are better ways to archive that but i just want a quick solution for myself.

- no additional test cases added. 
- manually tested with composer 1.10.16 and 2.0.3

to try it out add the following to your `composer.json`

```json
{
    "repositories": {
        "prestissimo": {
            "type": "vcs",
            "url": "https://github.com/c33s/prestissimo.git"
        }
    },
    "require": {
        "hirak/prestissimo": "dev-feature/composer2-compat",
    }
}
````